### PR TITLE
Fix ALSA period size to be 0.25s

### DIFF
--- a/console_callbacks.py
+++ b/console_callbacks.py
@@ -7,7 +7,7 @@ from connect_ffi import ffi, lib
 
 RATE = 44100
 CHANNELS = 2
-PERIODSIZE = 64
+PERIODSIZE = 44100 / 4 # 0.25s
 SAMPLESIZE = 2 # 16 bit integer
 MAXPERIODS = int(0.5 * RATE / PERIODSIZE) # 0.5s Buffer
 


### PR DESCRIPTION
On Pi 1, this fixes sound crackling and brings CPU down from 40% to 14%.

As far as I understand (sorry, first time ALSA / sound dev), no further changes are needed.

I used [pylibrespot](https://github.com/plietar/spotify-connect/blob/master/common/pylibrespot/sink.py#L14) as an example. Also see [this ALSA documentation page](http://www.alsa-project.org/main/index.php/FramesPeriods) for some detailed information. 
