### PR TITLE
gevent should be in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ MarkupSafe>=0.23
 pycparser>=2.10
 Werkzeug>=0.10.1
 pyalsaaudio>=0.7
+gevent>=1.0.1


### PR DESCRIPTION
Even if on some distros gevent cannot be installed using pip, it should be in requirements.txt. If it is already installed, pip should skip it.
