### PR TITLE
Remove dependencies of Flask from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,5 @@
 cffi>=0.9.2
 Flask>=0.10.1
 Flask-Bootstrap>=3.3.2.1
-itsdangerous>=0.24
-Jinja2>=2.7.3
-MarkupSafe>=0.23
 pycparser>=2.10
-Werkzeug>=0.10.1
 pyalsaaudio>=0.7


### PR DESCRIPTION
As far as I can see these are not directly used, they are just Flask dependencies. Tracking dependencies of dependencies is the package manager's job.
