### PR TITLE
Do not force usage of username&password (credentials can be saved)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Can either be installed via `pip` (requires the ALSA headers (`libasound2-dev` p
 ## Usage
 Tested against the rocki `libspotify_embedded_shared.so`
 ```
-usage: main.py [-h] [--device DEVICE] [--mixer MIXER] [--debug] [--key KEY]
+usage: main.py [-h] [--device DEVICE] [--mixer MIXER] [--dbrange RANGE}] [--debug] [--key KEY]
                [--username USERNAME] [--password PASSWORD] [--name NAME]
                [--bitrate {90,160,320}] [--credentials CREDENTIALS]
 
@@ -45,6 +45,8 @@ optional arguments:
                         alsa output device
   --mixer MIXER, -m MIXER
                         alsa mixer name for volume control
+  --dbrange RANGE, -r RANGE
+  						alsa mixer volume range in Db
   --debug, -d           enable libspotify_embedded/flask debug output
   --key KEY, -k KEY     path to spotify_appkey.key
   --username USERNAME, -u USERNAME

--- a/console_callbacks.py
+++ b/console_callbacks.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import argparse
 import alsaaudio as alsa
 import json
@@ -5,11 +6,11 @@ import Queue
 from threading import Thread
 import threading
 from connect_ffi import ffi, lib
-from __future__ import division
+
 
 RATE = 44100
 CHANNELS = 2
-PERIODSIZE = 44100 / 4 # 0.25s
+PERIODSIZE = int(44100 / 4) # 0.25s
 SAMPLESIZE = 2 # 16 bit integer
 MAXPERIODS = int(0.5 * RATE / PERIODSIZE) # 0.5s Buffer
 
@@ -87,12 +88,14 @@ class AlsaSink:
 session = PlaybackSession()
 device = AlsaSink(session, args)
 mixer = alsa.Mixer(args.mixer)
-#Gets mimimum volume Db
+
+#Gets mimimum volume Db for the mixer
 volume_range = (mixer.getrange()[1]-mixer.getrange()[0]) / 100
-selected_volume_range = args.dbrange
-if selected_volume_range < volume_range or selected_volume_range = 0:
+selected_volume_range = int(args.dbrange)
+if selected_volume_range > volume_range or selected_volume_range == 0:
     selected_volume_range = volume_range
 min_volume_range = (1 - selected_volume_range / volume_range) * 100
+print "min_volume_range: {}".format(min_volume_range)
 
 def userdata_wrapper(f):
     def inner(*args):
@@ -220,12 +223,16 @@ def playback_seek(self, millis):
 @userdata_wrapper
 def playback_volume(self, volume):
     print "playback_volume: {}".format(volume)
-    if volume = 0:
+    if volume == 0:
         mixer.setmute(1)
-    else
-        if mixer.getmute()[0] =  1:
+        print "Mute activated"
+    else:
+        if mixer.getmute()[0] ==  1:
             mixer.setmute(0)
-    mixer.setvolume(int(min_volume_range + ((100 - min_volume_range) / (volume / 655.35)) * 100))
+            print "Mute deactivated"
+        corected_playback_volume = int(min_volume_range + ((volume / 655.35) * (100 - min_volume_range) / 100))
+        print "corected_playback_volume: {}".format(corected_playback_volume)
+        mixer.setvolume(corected_playback_volume)
 
 connection_callbacks = ffi.new('SpConnectionCallbacks *', [
     connection_notify,


### PR DESCRIPTION
Allow usage of the "connect mode" when you already saved your credentials by using username & password once.

Also, I modified spotify-connect-web.sh this way : 

```
#!/bin/bash
set -e

DIR=~/spotify-connect-web-chroot
MAIN=main.py
if [ "$USER" == "root" ]; then
        SUDO=
else
        SUDO=sudo
fi

if [ "$1" == "install" ]; then
        mkdir -p $DIR
        cd $DIR
        curl http://spotify-connect-web.s3-website.eu-central-1.amazonaws.com/spotify-connect-web.tar.gz | $SUDO tar xz
else
        if [ "$1" == "connect" ]; then
                MAIN=connect.py
                shift
        fi
        trap "$SUDO umount $DIR/dev $DIR/proc" EXIT
        $SUDO mount --bind /dev $DIR/dev
        $SUDO mount -t proc proc $DIR/proc/
        $SUDO cp /etc/resolv.conf $DIR/etc/
        $SUDO chroot $DIR /bin/bash -c "cd /usr/src/app && python $MAIN $*"
fi
```

So it can be launched this way without web browser & it don't use sudo if already root : 
`./spotify-connect-web.sh connect --name MyConnect`
If you want to take it :)

Thanks for this project !
