### PR TITLE
Add Last.fm scrobbling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ libspotify_embedded_shared.so
 venv
 credentials.json
 spotify-connect-web.tar.gz
+lastfm_credentials.json

--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ optional arguments:
                         alsa mixer name for volume control
   --dbrange DBRANGE, -r DBRANGE
                         alsa mixer volume range in Db
+  --lastfm_username LASTFM_USERNAME
+                        your Last.fm username
+  --lastfm_password LASTFM_PASSWORD
+                        your Last.fm password
+  --lastfm_api_key LASTFM_API_KEY
+                        your Last.fm API key
+  --lastfm_api_secret LASTFM_API_SECRET
+                        your Last.fm API secret
+  --lastfm_credentials LASTFM_CREDENTIALS
+                        file to load Last.fm credentials from
   --cors CORS           enable CORS support for this host (for the web api).
                         Must be in the format <protocol>://<hostname>:<port>.
                         Port can be excluded if its 80 (http) or 443 (https).
@@ -109,6 +119,9 @@ After logging in successfully, a blob is sent by Spotify and saved to disk (to `
 
 ### Username/Password
 There's a login button on the webpage to enter a username and password, or you can pass the `--username` and `--password` arguments
+
+### Last.fm
+If you want to enable Last.fm scrobbling, you should first obtain API key at http://www.last.fm/api/account/create. You can pass your `--lastfm_username`, `--lastfm_password`, `--lastfm_api_key` and `--lastfm_api_secret` on the command line. You can also use `lastfm_credentials.json` and pass `--lastfm_credentials lastfm_credentials.json` to the command line. You need to explicitly pass the credentials file, otherwise the Last.fm module will not launch. 
 
 ### Passwordless/Multiuser (Zeroconf/Avahi)
 Zeroconf (Avahi) login can be used after executing the command `avahi-publish-service TestConnect _spotify-connect._tcp 4000 VERSION=1.0 CPath=/login/_zeroconf` (`avahi-publish-service` is in the `avahi-utils` package).

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ After logging in successfully, a blob is sent by Spotify and saved to disk (to `
 There's a login button on the webpage to enter a username and password, or you can pass the `--username` and `--password` arguments
 
 ### Last.fm
-If you want to enable Last.fm scrobbling, you should first obtain API key at http://www.last.fm/api/account/create. You can pass your `--lastfm_username`, `--lastfm_password`, `--lastfm_api_key` and `--lastfm_api_secret` on the command line. You can also use `lastfm_credentials.json` and pass `--lastfm_credentials lastfm_credentials.json` to the command line. You need to explicitly pass the credentials file, otherwise the Last.fm module will not launch. 
+If you want to enable Last.fm scrobbling, you should first obtain API key at http://www.last.fm/api/account/create. You can pass your `--lastfm_username`, `--lastfm_password`, `--lastfm_api_key` and `--lastfm_api_secret` on the command line. You can also use `lastfm_credentials.json` and pass `--lastfm_credentials lastfm_credentials.json` to the command line. You can find an example of the file format in `lastfm_credentials.json.dist`. You need to explicitly pass the credentials file, otherwise the Last.fm module will not launch. 
 
 ### Passwordless/Multiuser (Zeroconf/Avahi)
 Zeroconf (Avahi) login can be used after executing the command `avahi-publish-service TestConnect _spotify-connect._tcp 4000 VERSION=1.0 CPath=/login/_zeroconf` (`avahi-publish-service` is in the `avahi-utils` package).

--- a/connect.py
+++ b/connect.py
@@ -7,11 +7,12 @@ import json
 import uuid
 from connect_ffi import ffi, lib, C
 from console_callbacks import audio_arg_parser, mixer, error_callback, connection_callbacks, debug_callbacks, playback_callbacks, playback_setup
+from lastfm import lastfm_arg_parser
 from utils import print_zeroconf_vars
 
 class Connect:
     def __init__(self, error_cb = error_callback, web_arg_parser = None):
-        arg_parsers = [audio_arg_parser]
+        arg_parsers = [audio_arg_parser, lastfm_arg_parser]
         if web_arg_parser:
             arg_parsers.append(web_arg_parser)
         arg_parser = argparse.ArgumentParser(description='Web interface for Spotify Connect', parents=arg_parsers)

--- a/console_callbacks.py
+++ b/console_callbacks.py
@@ -6,6 +6,7 @@ import Queue
 from threading import Thread
 import threading
 from connect_ffi import ffi, lib
+from lastfm import lastfm
 
 
 RATE = 44100
@@ -165,11 +166,14 @@ def playback_notify(self, type):
     if type == lib.kSpPlaybackNotifyPlay:
         print "kSpPlaybackNotifyPlay"
         device.acquire()
+        lastfm.play()
     elif type == lib.kSpPlaybackNotifyPause:
         print "kSpPlaybackNotifyPause"
+        lastfm.pause()
         device.release()
     elif type == lib.kSpPlaybackNotifyTrackChanged:
         print "kSpPlaybackNotifyTrackChanged"
+        lastfm.track_changed()
     elif type == lib.kSpPlaybackNotifyNext:
         print "kSpPlaybackNotifyNext"
     elif type == lib.kSpPlaybackNotifyPrev:

--- a/lastfm.py
+++ b/lastfm.py
@@ -1,0 +1,106 @@
+import argparse
+import json
+import pylast
+import time
+from connect_ffi import lib
+from utils import get_metadata
+
+lastfm_arg_parser = argparse.ArgumentParser(add_help=False)
+
+lastfm_arg_parser.add_argument('--lastfm_username', help='your Last.fm username', default=None)
+lastfm_arg_parser.add_argument('--lastfm_password', help='your Last.fm password', default=None)
+lastfm_arg_parser.add_argument('--lastfm_api_key', help='your Last.fm API key', default=None)
+lastfm_arg_parser.add_argument('--lastfm_api_secret', help='your Last.fm API secret', default=None)
+lastfm_arg_parser.add_argument('--lastfm_credentials', help='file to load Last.fm credentials from', default=None)
+
+args = lastfm_arg_parser.parse_known_args()[0]
+
+class LastFM:
+    def __init__(self):
+        self.credentials = dict({
+            'username': None,
+            'password': None,
+            'api_key': None,
+            'api_secret': None
+        })
+
+        if args.lastfm_credentials:
+            with open(args.lastfm_credentials) as f:
+                self.credentials.update(
+                    {k: v.encode('utf-8') if isinstance(v, unicode) else v
+                        for (k, v)
+                        in json.loads(f.read()).iteritems()})
+
+        if args.lastfm_username:
+            self.credentials['username'] = args.lastfm_username
+        if args.lastfm_password:
+            self.credentials['password'] = args.lastfm_password
+        if args.lastfm_api_key:
+            self.credentials['api_key'] = args.lastfm_api_key
+        if args.lastfm_api_secret:
+            self.credentials['api_secret'] = args.lastfm_api_secret
+
+        if not (self.credentials['username'] and
+                self.credentials['password'] and
+                self.credentials['api_key'] and
+                self.credentials['api_secret']):
+            self.on = False
+            print 'Last.fm: incomplete credentials, not launched'
+            return
+
+        self.on = True
+        self.lastfm_network = pylast.LastFMNetwork(
+            api_key=self.credentials['api_key'],
+            api_secret=self.credentials['api_secret'],
+            username=self.credentials['username'],
+            password_hash=pylast.md5(self.credentials['password'])
+        )
+        self.metadata = None
+        self.timestamp = None
+        self.playing = bool(lib.SpPlaybackIsPlaying())
+        self.play_cumul = 0
+        self.play_beg = time.time()
+
+    # This two functions are used to count the playing time of each song
+    def pause(self):
+        if not self.on:
+            return
+        if self.playing:
+            print "LastFM: add " + str(time.time() - self.play_beg) + " to total played time"
+            self.play_cumul += time.time() - self.play_beg
+            print "LastFM: total play time is " + str(self.play_cumul)
+        self.playing = False
+
+    def play(self):
+        if not self.on:
+            return
+        if not self.playing:
+            self.play_beg = time.time()
+        self.playing = True
+
+    def track_changed(self):
+        if not self.on:
+            return
+        if not bool(lib.SpPlaybackIsActiveDevice()):
+            return
+        self.pause()
+        # Scrobble last song only if the song has been played more than half
+        # of its duration or during more than 4 minutes
+        if self.metadata and self.play_cumul > min(self.metadata["duration"] / 2000, 240):
+            self.lastfm_network.scrobble(artist=self.metadata["artist_name"],
+                title=self.metadata["track_name"],
+                timestamp=int(self.metadata["time_on"]),
+                album=self.metadata["album_name"],
+                duration=(self.metadata["duration"] / 1000))
+            print "LastFM: scrobbled track " + self.metadata["track_name"] + " - " + self.metadata["artist_name"]
+
+        # Update now playing song
+        self.play_cumul = 0
+        self.play()
+        self.metadata = get_metadata()
+        self.metadata["time_on"] = time.time()
+        self.lastfm_network.update_now_playing(artist=self.metadata["artist_name"],
+            title=self.metadata["track_name"], album=self.metadata["album_name"],
+            duration=int(self.metadata["duration"] / 1000))
+
+lastfm = LastFM()

--- a/lastfm_credentials.json.dist
+++ b/lastfm_credentials.json.dist
@@ -1,0 +1,6 @@
+{
+    "api_key": "Put your API Key here",
+    "api_secret": "You can get your API key and secret on http://www.last.fm/api/account/create",
+    "username": "username",
+    "password": "password"
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Flask-Cors==2.1.2
 pycparser>=2.10
 pyalsaaudio>=0.7
 gevent>=1.0.1
+pylast>=1.6.0


### PR DESCRIPTION
Implement Last.fm scrobbling thanks to [pylast](https://github.com/pylast/pylast).

By default, Last.fm scrobbling is not enabled.

To enable Last.fm scrobbling, they can pass your `--lastfm_username`, `--lastfm_password`, `--lastfm_api_key` and `--lastfm_api_secret` on the command line.
They can also use `lastfm_credentials.json` and pass `--lastfm_credentials lastfm_credentials.json` to the command line.

The user needs to explicitly pass the name of the credentials file, otherwise the Last.fm module will not launch.
