### PR TITLE
Volume sounds best when using a logarithmic scale

### DIFF
--- a/connect.py
+++ b/connect.py
@@ -9,6 +9,7 @@ from connect_ffi import ffi, lib, C
 from console_callbacks import audio_arg_parser, mixer, error_callback, connection_callbacks, debug_callbacks, playback_callbacks, playback_setup
 from lastfm import lastfm_arg_parser
 from utils import print_zeroconf_vars
+import math
 
 class Connect:
     def __init__(self, error_cb = error_callback, web_arg_parser = None):
@@ -87,7 +88,7 @@ class Connect:
         lib.SpRegisterConnectionCallbacks(connection_callbacks, userdata)
         lib.SpRegisterPlaybackCallbacks(playback_callbacks, userdata)
 
-        mixer_volume = int(mixer.getvolume()[0] * 655.35)
+        mixer_volume = int(math.pow(mixer.getvolume()[0] / 100.0, 3) * 65535)
         lib.SpPlaybackUpdateVolume(mixer_volume)
 
         bitrates = {

--- a/console_callbacks.py
+++ b/console_callbacks.py
@@ -7,6 +7,7 @@ from threading import Thread
 import threading
 from connect_ffi import ffi, lib
 from lastfm import lastfm
+import math
 
 
 RATE = 44100
@@ -257,6 +258,7 @@ def playback_volume(self, volume):
             mixer.setmute(0)
             print "Mute deactivated"
         corected_playback_volume = int(min_volume_range + ((volume / 655.35) * (100 - min_volume_range) / 100))
+        corected_playback_volume = int(100 * math.pow(corected_playback_volume / 100.0, 1.0 / 3.0))
         print "corected_playback_volume: {}".format(corected_playback_volume)
         mixer.setvolume(corected_playback_volume)
 


### PR DESCRIPTION
This commit adds a cubic scale to the correct playback volume, which results in a more linear _sounding_ volume response. You can confirm this by watching the slider on alsamixer, which now moves linearly where it didn’t before, as the alsamixer slider accounts for this logarithmic volume scale.